### PR TITLE
fix(package): update ai-commit bin path and add version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-commit-generator",
   "bin": {
-    "ai-commit": "./cli/index.js"
+    "ai-commit": "cli/index.js"
   },
   "main": "./cli/index.js",
   "type": "module",
@@ -16,5 +16,6 @@
     "simple-git": "^3.27.0",
     "typescript": "5.7.3",
     "winston": "^3.17.0"
-  }
+  },
+  "version": "1.0.0"
 }


### PR DESCRIPTION
- Changed the path for the ai-commit binary in package.json from './cli/index.js' to 'cli/index.js' to align with directory structure.
- Added version field set to '1.0.0' in package.json.