### PR TITLE
Rename package for commit message generator

### DIFF
--- a/cli/index.js
+++ b/cli/index.js
@@ -11,7 +11,7 @@ const program = new Command();
 setupLogger();
 
 program
-  .name("commit-gpt")
+  .name("@aigen/commit-gen")
   .description("Generate AI-crafted commit messages")
   // .option("-g, --generate", "Generate a commit message")
   .version("1.0.0");


### PR DESCRIPTION
- Changed CLI name from "commit-gpt" to "@aigen/commit-gen"
- Updated description to reflect the new package name