### PR TITLE
Rename project from "commitly" to "commitai"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# commitai 🚀  
+# commitaai 🚀  
 
 AI-powered commit message generator using OpenAI. Get meaningful and structured commit messages in seconds!  
  
 
-[![NPM Version](https://img.shields.io/npm/v/fireorm.svg?style=flat)](https://www.npmjs.com/package/commitai)
+[![NPM Version](https://img.shields.io/npm/v/fireorm.svg?style=flat)](https://www.npmjs.com/package/commitaai)
 [![All Contributors](https://img.shields.io/badge/all_contributors-1-orange.svg?style=flat-square)](#contributors)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE) 
 ---
@@ -22,13 +22,13 @@ AI-powered commit message generator using OpenAI. Get meaningful and structured 
 No need to install globally. Use it directly via `npx`:  
 
 ```bash
-npx commitai generate  # Generate commit message
+npx commitaai generate  # Generate commit message
 ```
 
 Alternatively, install globally:
 
 ```bash
-npm install -g commitai
+npm install -g commitaai
 ```
 
 ## 🔥 Usage
@@ -37,14 +37,14 @@ npm install -g commitai
 Generate a Commit Message
 
 ```bash
-npx commitai generate
+npx commitaai generate
 // or
-npx commitai g
+npx commitaai g
 ```
 
 ## Configure OpenAI API Key
 ```bash
-npx commitai configure
+npx commitaai configure
 ```
 
 This securely stores your API key in `~/.env`.
@@ -52,7 +52,7 @@ This securely stores your API key in `~/.env`.
 Commit with AI-generated Message
 ```bash
 git add .
-npx commitai generate
+npx commitaai generate
 ```
 After generating the commit message, you’ll be asked to confirm before it is committed.
 
@@ -73,4 +73,4 @@ PRs are welcome! If you’d like to improve the tool, check out `CONTRIBUTING.md
 
 ## 📜 License
 
-MIT © [Vincent Muriuki](https://github.com/vincentmuriuki). See [LICENSE](https://github.com/vincentmuriuki/commitai/blob/master/LICENSE) for details.
+MIT © [Vincent Muriuki](https://github.com/vincentmuriuki). See [LICENSE](https://github.com/vincentmuriuki/commitaai/blob/master/LICENSE) for details.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# commitly 🚀  
+# commitai 🚀  
 
 AI-powered commit message generator using OpenAI. Get meaningful and structured commit messages in seconds!  
  
 
-[![NPM Version](https://img.shields.io/npm/v/fireorm.svg?style=flat)](https://www.npmjs.com/package/commitly)
+[![NPM Version](https://img.shields.io/npm/v/fireorm.svg?style=flat)](https://www.npmjs.com/package/commitai)
 [![All Contributors](https://img.shields.io/badge/all_contributors-1-orange.svg?style=flat-square)](#contributors)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE) 
 ---
@@ -22,13 +22,13 @@ AI-powered commit message generator using OpenAI. Get meaningful and structured 
 No need to install globally. Use it directly via `npx`:  
 
 ```bash
-npx commitly generate  # Generate commit message
+npx commitai generate  # Generate commit message
 ```
 
 Alternatively, install globally:
 
 ```bash
-npm install -g commitly
+npm install -g commitai
 ```
 
 ## 🔥 Usage
@@ -37,14 +37,14 @@ npm install -g commitly
 Generate a Commit Message
 
 ```bash
-npx commitly generate
+npx commitai generate
 // or
-npx commitly g
+npx commitai g
 ```
 
 ## Configure OpenAI API Key
 ```bash
-npx commitly configure
+npx commitai configure
 ```
 
 This securely stores your API key in `~/.env`.
@@ -52,7 +52,7 @@ This securely stores your API key in `~/.env`.
 Commit with AI-generated Message
 ```bash
 git add .
-npx commitly generate
+npx commitai generate
 ```
 After generating the commit message, you’ll be asked to confirm before it is committed.
 
@@ -73,4 +73,4 @@ PRs are welcome! If you’d like to improve the tool, check out `CONTRIBUTING.md
 
 ## 📜 License
 
-This project is licensed under the MIT License. See LICENSE for details.
+MIT © [Vincent Muriuki](https://github.com/vincentmuriuki). See [LICENSE](https://github.com/vincentmuriuki/commitai/blob/master/LICENSE) for details.

--- a/cli/index.js
+++ b/cli/index.js
@@ -11,7 +11,7 @@ const program = new Command();
 setupLogger();
 
 program
-  .name("commitai")
+  .name("commitaai")
   .description("Generate AI-crafted commit messages")
   // .option("-g, --generate", "Generate a commit message")
   .version("1.0.2");

--- a/cli/index.js
+++ b/cli/index.js
@@ -11,7 +11,7 @@ const program = new Command();
 setupLogger();
 
 program
-  .name("commitly")
+  .name("commitai")
   .description("Generate AI-crafted commit messages")
   // .option("-g, --generate", "Generate a commit message")
   .version("1.0.2");

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "commitly",
+  "name": "commitai",
   "bin": {
-    "commitly": "cli/index.js"
+    "commitai": "cli/index.js"
   },
   "main": "./cli/index.js",
   "type": "module",
@@ -22,6 +22,6 @@
 		"access": "public"
 	},
   "keywords": [
-		"commitly"
+		"commitai"
 	]
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "commitai",
+  "name": "commitaai",
   "bin": {
-    "commitai": "cli/index.js"
+    "commitaai": "cli/index.js"
   },
   "main": "./cli/index.js",
   "type": "module",
@@ -22,6 +22,6 @@
 		"access": "public"
 	},
   "keywords": [
-		"commitai"
+		"commitaai"
 	]
 }


### PR DESCRIPTION
- Updated README.md to reflect the new project name and usage instructions.
- Changed CLI command references from "commitly" to "commitai".
- Modified the package.json to rename the package and update the bin entry.
- Updated NPM version badge links accordingly.

This change enhances branding and aligns with the AI focus of the tool.