### PR TITLE
chore: bump version to 0.0.3

### DIFF
--- a/cli/index.js
+++ b/cli/index.js
@@ -15,7 +15,7 @@ setupLogger();
 program
   .name("commitaai")
   .description(chalk.blue("Generate AI-crafted commit messages"))
-  .version("0.0.2")
+  .version("0.0.3")
   .addCommand(generateCommand)
   .command("configure")
   .description("Update or set OpenAI API key")

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "lint:fix": "eslint --fix",
     "prepare": "husky"
   },
-  "version": "0.0.2",
+  "version": "0.0.3",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
- Updated CLI version in index.js from 0.0.2 to 0.0.3
- Updated package.json version from 0.0.2 to 0.0.3